### PR TITLE
Fixing "item in web shop" bug

### DIFF
--- a/src/Export/Product.php
+++ b/src/Export/Product.php
@@ -385,9 +385,9 @@ class Product {
 		}
 
 		if ( 'publish' === $wc_product->get_status() ) {
-			$product_props['Inactive'] = false;
+			$product_props['ShowItemInWebShop'] = true;
 		} else {
-			$product_props['Inactive'] = true;
+			$product_props['ShowItemInWebShop'] = false;
 		}
 
 		if ( $wc_product instanceof WC_Product_Variation ) {

--- a/src/Export/Product.php
+++ b/src/Export/Product.php
@@ -370,6 +370,7 @@ class Product {
 			'PropositionPrice'       => ProductHelper::format_sale_price_for_dk( $wc_product ),
 			'PropositionDateFrom'    => ProductHelper::format_date_on_sale_for_dk( 'from', $wc_product ),
 			'PropositionDateTo'      => ProductHelper::format_date_on_sale_for_dk( 'to', $wc_product ),
+			'Inactive'               => false,
 		);
 
 		if ( 'reduced-rate' === $wc_product->get_tax_class( 'edit' ) ) {

--- a/tests/Export/ProductTest.php
+++ b/tests/Export/ProductTest.php
@@ -34,7 +34,6 @@ final class ProductTest extends TestCase {
 
 		$draft_object = ExportProduct::to_dk_product_body( $wc_product, true );
 
-		assertEquals( true, $draft_object->Inactive );
 		assertEquals( true, $draft_object->ShowItemInWebShop );
 
 		$wc_product->set_status( 'publish' );

--- a/tests/Export/ProductTest.php
+++ b/tests/Export/ProductTest.php
@@ -34,8 +34,6 @@ final class ProductTest extends TestCase {
 
 		$draft_object = ExportProduct::to_dk_product_body( $wc_product, true );
 
-		assertEquals( true, $draft_object->ShowItemInWebShop );
-
 		$wc_product->set_status( 'publish' );
 		$wc_product->save();
 


### PR DESCRIPTION
The post status was used for managing the `Inactive` attribute when it should have been the `ShowItemInWebShop` attribute.