### PR TITLE
Fixing product variant sync

### DIFF
--- a/src/Hooks/WooUpdateProduct.php
+++ b/src/Hooks/WooUpdateProduct.php
@@ -29,6 +29,13 @@ class WooUpdateProduct {
 		);
 
 		add_action(
+			'woocommerce_update_product_variation',
+			array( __CLASS__, 'on_product_update' ),
+			10,
+			2
+		);
+
+		add_action(
 			'before_delete_post',
 			array( __CLASS__, 'before_post_delete' ),
 			10,

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -309,7 +309,7 @@ class Products {
 		int $product_id,
 		stdClass $json_object
 	): WC_Product|false {
-		$wc_product = new WC_Product( $product_id );
+		$wc_product = wc_get_product( $product_id );
 
 		if ( ! ( $wc_product instanceof WC_Product ) ) {
 			return false;


### PR DESCRIPTION
Product variations were being converted into single products during a downstream sync. This should fixed that.

Variations are now also caught during a upstream sync.