### PR TITLE
Adding support for product variants

### DIFF
--- a/js/products.js
+++ b/js/products.js
@@ -1,0 +1,48 @@
+class NineteenEightyWooProducts {
+	static actionSelect() {
+		return document.getElementById( 'bulk-action-selector-top' );
+	}
+
+	static addProductIdInputToActions() {
+		let actionsContainer = document.querySelector( '#posts-filter .bulkactions' );
+		let actionButton     = document.getElementById( 'doaction' );
+		let productIdInput   = document.createElement( 'input' );
+		let spacerTextNode   = document.createTextNode( ' ' );
+
+		productIdInput.setAttribute( 'type', 'text' );
+		productIdInput.setAttribute( 'name', 'action_post_id' );
+		productIdInput.setAttribute( 'id', 'action_post_id_input' );
+		productIdInput.setAttribute( 'placeholder', 'Parent ID' );
+
+		actionsContainer.insertBefore( productIdInput, actionButton );
+		actionsContainer.insertBefore( spacerTextNode, actionButton );
+	}
+
+	static removeProductInputFromActions() {
+		let element = document.getElementById( 'action_post_id_input' );
+
+		if ( element !== null ) {
+			element.remove();
+		}
+	}
+
+	static selectMenuEvent( e ) {
+		if ( e.target.value == 'convert_to_variant' ) {
+			NineteenEightyWooProducts.addProductIdInputToActions();
+		} else {
+			NineteenEightyWooProducts.removeProductInputFromActions();
+		}
+	}
+}
+
+window.addEventListener(
+	'DOMContentLoaded',
+	() => {
+		NineteenEightyWooProducts.actionSelect().addEventListener(
+			'change',
+			( e ) => {
+				NineteenEightyWooProducts.selectMenuEvent( e );
+			}
+		);
+	}
+);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,12 @@
 	<!-- Use WordPress as the basis of our ruleset -->
 	<rule ref="WordPress">
 		<!--
+		Absolutely ignoring that slow queries may occur when looking things up
+		by meta.
+		-->
+		<exclude name="WordPress.DB.SlowDBQuery" />
+
+		<!--
 		We are not limited by WordPress' naming constraints and are using PSR-4
 		autoloading, so we'll use that file naming convention.
 		-->

--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -59,7 +59,6 @@ class Invoice {
 		}
 
 		if ( 200 !== $result->response_code ) {
-			var_dump( $result );
 			return false;
 		}
 

--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -59,6 +59,7 @@ class Invoice {
 		}
 
 		if ( 200 !== $result->response_code ) {
+			var_dump( $result );
 			return false;
 		}
 

--- a/src/Export/Order.php
+++ b/src/Export/Order.php
@@ -191,7 +191,7 @@ class Order {
 				}
 
 				if ( key_exists( 1, $variation_attributes ) ) {
-					$variation_line['Code2'] = $variation->get_attribute( $variation_attributes[1] );;
+					$variation_line['Code2'] = $variation->get_attribute( $variation_attributes[1] );
 				}
 
 				$variation_line['Quantity'] = $item->get_quantity();

--- a/src/Export/Product.php
+++ b/src/Export/Product.php
@@ -424,7 +424,7 @@ class Product {
 
 		if ( ProductHelper::name_sync_enabled( $wc_product ) ) {
 			$name_props = array(
-				'Description' => $wc_product->get_title(),
+				'Description' => $wc_product->get_name(),
 			);
 
 			if ( $wc_product instanceof WC_Product_Variation ) {
@@ -434,16 +434,7 @@ class Product {
 			$product_props = array_merge( $product_props, $name_props );
 		}
 
-		$product_dk_currency = $wc_product->get_meta(
-			'1984_woo_dk_dk_currency',
-			true,
-			'edit'
-		);
-
-		if (
-			( get_woocommerce_currency() === $product_dk_currency ) &&
-			ProductHelper::price_sync_enabled( $wc_product )
-		) {
+		if ( ProductHelper::price_sync_enabled( $wc_product ) ) {
 			$price_props = array(
 				'CurrencyCode'        => get_woocommerce_currency(),
 				'TaxPercent'          => ProductHelper::tax_rate( $wc_product ),

--- a/src/Export/Product.php
+++ b/src/Export/Product.php
@@ -365,6 +365,7 @@ class Product {
 	public static function to_new_product_body(
 		WC_Product $wc_product
 	): stdClass {
+		$parent        = wc_get_product( $wc_product->get_parent_id() );
 		$product_props = array(
 			'ItemCode'               => $wc_product->get_sku(),
 			'Description'            => $wc_product->get_title(),
@@ -380,6 +381,30 @@ class Product {
 			'Inactive'               => false,
 		);
 
+		if ( $wc_product instanceof WC_Product_Variation ) {
+			if ( 'product' === $wc_product->get_meta( '1984_dk_woo_origin' ) ) {
+				$product_props['Description'] = $wc_product->get_meta(
+					'1984_dk_woo_original_name',
+					true
+				);
+
+				if ( $parent ) {
+					$description = implode(
+						'; ',
+						array(
+							$wc_product->get_title(),
+							$wc_product->get_attribute_summary(),
+						)
+					);
+
+					$product_props['Description2'] = $description;
+				}
+			} else {
+				$product_props['Description']  = $wc_product->get_title();
+				$product_props['Description2'] = $wc_product->get_attribute_summary();
+			}
+		}
+
 		if ( true === wc_prices_include_tax() ) {
 			$product_props['UnitPrice1WithTax'] = $wc_product->get_regular_price();
 		} else {
@@ -390,10 +415,6 @@ class Product {
 			$product_props['ShowItemInWebShop'] = true;
 		} else {
 			$product_props['ShowItemInWebShop'] = false;
-		}
-
-		if ( $wc_product instanceof WC_Product_Variation ) {
-			$product_props['Description2'] = $wc_product->get_attribute_summary();
 		}
 
 		$ledger_codes = ProductHelper::get_ledger_codes( $wc_product );
@@ -423,15 +444,25 @@ class Product {
 		$product_props = array();
 
 		if ( ProductHelper::name_sync_enabled( $wc_product ) ) {
-			$name_props = array(
-				'Description' => $wc_product->get_name(),
-			);
-
 			if ( $wc_product instanceof WC_Product_Variation ) {
-				$name_props['Description2'] = $wc_product->get_attribute_summary();
-			}
+				$name = $wc_product->get_meta(
+					'1984_dk_woo_original_name',
+					true
+				);
 
-			$product_props = array_merge( $product_props, $name_props );
+				$description = implode(
+					'; ',
+					array(
+						$wc_product->get_title(),
+						$wc_product->get_attribute_summary(),
+					)
+				);
+
+				$product_props['Description']  = $name;
+				$product_props['Description2'] = $description;
+			} else {
+				$product_props['Description'] = $wc_product->get_name();
+			}
 		}
 
 		if ( ProductHelper::price_sync_enabled( $wc_product ) ) {

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -299,20 +299,23 @@ class Product {
 			return false;
 		}
 
+		$post       = get_post( $product_id );
+		$post_title = $post->post_title;
+
 		set_post_type( $product_id, 'product_variation' );
 
-		$wc_product    = wc_get_product( $product_id );
-		$original_name = $wc_product->get_name();
+		$wc_product = wc_get_product( $product_id );
 
 		if ( 'draft' === $wc_product->get_status( 'edit' ) ) {
 			$wc_product->set_status( 'private' );
 		}
 
 		$wc_product->set_parent_id( $parent_id );
-		$wc_product->set_name( $original_name );
+		$wc_product->set_name( $post_title );
+
 
 		if ( 0 !== $wc_product->save() ) {
-			return true;
+			return $wc_product->get_id();
 		}
 
 		return false;

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -233,7 +233,10 @@ class Product {
 			return false;
 		}
 
-		if ( 'product_variation' === $wc_product->get_meta( '1984_dk_woo_origin', true, 'edit' ) ) {
+		if (
+			'product_variation' ===
+			$wc_product->get_meta( '1984_dk_woo_origin', true, 'edit' )
+		) {
 			return false;
 		}
 

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -302,6 +302,10 @@ class Product {
 		$post       = get_post( $product_id );
 		$post_title = $post->post_title;
 
+		if ( is_null( $post ) ) {
+			return false;
+		}
+
 		set_post_type( $product_id, 'product_variation' );
 
 		$wc_product = wc_get_product( $product_id );

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -319,8 +319,7 @@ class Product {
 			return false;
 		}
 
-		$post       = get_post( $product_id );
-		$post_title = $post->post_title;
+		$post = get_post( $product_id );
 
 		if ( is_null( $post ) ) {
 			return false;
@@ -335,7 +334,6 @@ class Product {
 		}
 
 		$wc_product->set_parent_id( $parent_id );
-		$wc_product->set_name( $post_title );
 
 		// We indicate it here that this variant was originally a product.
 		$wc_product->update_meta_data( '1984_dk_woo_origin', 'product' );

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -294,7 +294,7 @@ class Product {
 	public static function convert_to_variant(
 		int $product_id,
 		int $parent_id
-	): bool {
+	): int|false {
 		if ( 'product' !== get_post_type( $product_id ) ) {
 			return false;
 		}

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -7,9 +7,12 @@ namespace NineteenEightyFour\NineteenEightyWoo\Helpers;
 use NineteenEightyFour\NineteenEightyWoo\Config;
 use NineteenEightyFour\NineteenEightyWoo\Brick\Math\BigDecimal;
 use NineteenEightyFour\NineteenEightyWoo\Brick\Math\RoundingMode;
+use NineteenEightyFour\NineteenEightyWoo\Hooks\WooUpdateProduct as WooUpdateProductHooks;
 use WC_Product;
+use WC_Product_Variation;
 use WC_Tax;
 use WC_DateTime;
+use WP_Post;
 
 /**
  * The Product Helper Class
@@ -28,6 +31,10 @@ class Product {
 	 * @return bool True if name sync is enabled, false if not.
 	 */
 	public static function name_sync_enabled( WC_Product $wc_product ): bool {
+		if ( $wc_product instanceof WC_Product_Variation ) {
+			$wc_product = wc_get_product( $wc_product->get_parent_id() );
+		}
+
 		$meta_value = $wc_product->get_meta(
 			'1984_woo_dk_name_sync',
 			true,
@@ -55,6 +62,26 @@ class Product {
 	 * @return bool True if price sync is enabled, false if not.
 	 */
 	public static function price_sync_enabled( WC_Product $wc_product ): bool {
+		if ( $wc_product instanceof WC_Product_Variation ) {
+			$parent = wc_get_product( $wc_product->get_parent_id() );
+			if ( $parent ) {
+				$wc_product = $parent;
+			}
+		}
+
+		$product_dk_currency = $wc_product->get_meta(
+			'1984_woo_dk_dk_currency',
+			true,
+			'edit'
+		);
+
+		if (
+			( ! empty( $product_dk_currency ) ) &&
+			( get_woocommerce_currency() !== $product_dk_currency )
+		) {
+			return false;
+		}
+
 		$meta_value = $wc_product->get_meta(
 			'1984_woo_dk_price_sync',
 			true,
@@ -84,6 +111,13 @@ class Product {
 	public static function quantity_sync_enabled(
 		WC_Product $wc_product
 	): bool {
+		if ( $wc_product instanceof WC_Product_Variation ) {
+			$parent = wc_get_product( $wc_product->get_parent_id() );
+			if ( $parent ) {
+				$wc_product = $parent;
+			}
+		}
+
 		$meta_value = $wc_product->get_meta(
 			'1984_woo_dk_stock_sync',
 			true,
@@ -246,6 +280,41 @@ class Product {
 					'purchase' => Config::get_ledger_code( 'standard_purchase' ),
 				);
 		}
+		return false;
+	}
+
+	/**
+	 * Convert a product to variant
+	 *
+	 * @param int $product_id The product ID.
+	 * @param int $parent_id The ID of the new variant's parent.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public static function convert_to_variant(
+		int $product_id,
+		int $parent_id
+	): bool {
+		if ( 'product' !== get_post_type( $product_id ) ) {
+			return false;
+		}
+
+		set_post_type( $product_id, 'product_variation' );
+
+		$wc_product    = wc_get_product( $product_id );
+		$original_name = $wc_product->get_name();
+
+		if ( 'draft' === $wc_product->get_status( 'edit' ) ) {
+			$wc_product->set_status( 'private' );
+		}
+
+		$wc_product->set_parent_id( $parent_id );
+		$wc_product->set_name( $original_name );
+
+		if ( 0 !== $wc_product->save() ) {
+			return true;
+		}
+
 		return false;
 	}
 }

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -233,6 +233,26 @@ class Product {
 			return false;
 		}
 
+		if ( 'product_variation' === $wc_product->get_meta( '1984_dk_woo_origin', true, 'edit' ) ) {
+			return false;
+		}
+
+		$parent_id = $wc_product->get_parent_id();
+
+		if ( 0 !== $parent_id ) {
+			$parent = wc_get_product( $parent_id );
+
+			if (
+				'product_variation' === $parent->get_meta(
+					'1984_dk_woo_origin',
+					true,
+					'edit'
+				)
+			) {
+				return false;
+			}
+		}
+
 		return true;
 	}
 

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -313,6 +313,8 @@ class Product {
 		$wc_product->set_parent_id( $parent_id );
 		$wc_product->set_name( $post_title );
 
+		// We indicate it here that this variant was originally a product.
+		$wc_product->update_meta_data( '1984_dk_woo_origin', 'product' );
 
 		if ( 0 !== $wc_product->save() ) {
 			return $wc_product->get_id();

--- a/src/Helpers/Product.php
+++ b/src/Helpers/Product.php
@@ -322,13 +322,18 @@ class Product {
 			return false;
 		}
 
-		$post = get_post( $product_id );
+		$post  = get_post( $product_id );
+		$title = $post->post_title;
 
 		if ( is_null( $post ) ) {
 			return false;
 		}
 
-		set_post_type( $product_id, 'product_variation' );
+		$parent = wc_get_product( $parent_id );
+
+		if ( ! $parent ) {
+			return false;
+		}
 
 		$wc_product = wc_get_product( $product_id );
 
@@ -340,6 +345,7 @@ class Product {
 
 		// We indicate it here that this variant was originally a product.
 		$wc_product->update_meta_data( '1984_dk_woo_origin', 'product' );
+		$wc_product->update_meta_data( '1984_dk_woo_original_name', $title );
 
 		if ( 0 !== $wc_product->save() ) {
 			return $wc_product->get_id();

--- a/src/Hooks/Admin.php
+++ b/src/Hooks/Admin.php
@@ -69,8 +69,13 @@ class Admin {
 	 * @param WP_Screen $current_screen The current screen. In our case it
 	 *                  should be the `edit-product` screen.
 	 */
-	public static function enqueue_products_styles_and_scripts( WP_Screen $current_screen ): void {
-		if ( 'edit-product' === $current_screen->id ) {
+	public static function enqueue_products_styles_and_scripts(
+		WP_Screen $current_screen
+	): void {
+		if (
+			current_user_can( 'edit_others_posts' ) &&
+			'edit-product' === $current_screen->id
+		) {
 			wp_enqueue_style(
 				handle: 'nineteen-eighty-woo-products',
 				src: plugins_url( 'style/products.css', dirname( __DIR__ ) ),
@@ -101,10 +106,12 @@ class Admin {
 	public static function register_product_to_variant_bulk_action(
 		array $bulk_actions
 	): array {
-		$bulk_actions['convert_to_variant'] = __(
-			'Convert to Product Variant',
-			'1984-dk-woo'
-		);
+		if ( current_user_can( 'edit_others_posts' ) ) {
+			$bulk_actions['convert_to_variant'] = __(
+				'Convert to Product Variant',
+				'1984-dk-woo'
+			);
+		}
 
 		return $bulk_actions;
 	}
@@ -123,6 +130,10 @@ class Admin {
 		string $doaction,
 		array $post_ids
 	): string {
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
+			return $sendback;
+		}
+
 		if ( 'convert_to_variant' !== $doaction ) {
 			return $sendback;
 		}

--- a/src/Hooks/Admin.php
+++ b/src/Hooks/Admin.php
@@ -9,6 +9,7 @@ use NineteenEightyFour\NineteenEightyWoo\Export\Product;
 use NineteenEightyFour\NineteenEightyWoo\Export\SalesPerson;
 use NineteenEightyFour\NineteenEightyWoo\Export\Customer;
 use NineteenEightyFour\NineteenEightyWoo\Helpers\Product as ProductHelper;
+use NineteenEightyFour\NineteenEightyWoo\Import\ProductVariations;
 use stdClass;
 use WP_Screen;
 
@@ -61,6 +62,32 @@ class Admin {
 			10,
 			3
 		);
+
+		add_filter(
+			'woocommerce_variation_option_name',
+			array( __CLASS__, 'handle_variation_option_name' ),
+			10,
+			1
+		);
+
+		add_filter(
+			'woocommerce_attribute_label',
+			array( __CLASS__, 'handle_variation_label' ),
+			10,
+			3
+		);
+	}
+
+	public static function handle_variation_label( $label, $name, $product ) {
+		$variation_attribute = ProductVariations::get_attribute( $label );
+		if ( ! $variation_attribute ) {
+			return $label;
+		}
+		return $variation_attribute->description;
+	}
+
+	public static function handle_variation_option_name( $name ) {
+		return ProductVariations::get_attribute_name( $name );
 	}
 
 	/**

--- a/src/Hooks/Admin.php
+++ b/src/Hooks/Admin.php
@@ -62,32 +62,6 @@ class Admin {
 			10,
 			3
 		);
-
-		add_filter(
-			'woocommerce_variation_option_name',
-			array( __CLASS__, 'handle_variation_option_name' ),
-			10,
-			1
-		);
-
-		add_filter(
-			'woocommerce_attribute_label',
-			array( __CLASS__, 'handle_variation_label' ),
-			10,
-			3
-		);
-	}
-
-	public static function handle_variation_label( $label, $name, $product ) {
-		$variation_attribute = ProductVariations::get_attribute( $label );
-		if ( ! $variation_attribute ) {
-			return $label;
-		}
-		return $variation_attribute->description;
-	}
-
-	public static function handle_variation_option_name( $name ) {
-		return ProductVariations::get_attribute_name( $name );
 	}
 
 	/**

--- a/src/Hooks/WooProductVariations.php
+++ b/src/Hooks/WooProductVariations.php
@@ -172,35 +172,4 @@ class WooProductVariations {
 
 		$product_variation->save();
 	}
-
-	public static function set_stock_quantity_from_dk_variations(
-		int $id,
-		WC_Product_Variation $product_variation
-	) {
-		$parent_id = $product_variation->get_parent_id();
-		$parent    = wc_get_product( $parent_id );
-
-		if ( ! ProductHelper::quantity_sync_enabled( $parent ) ) {
-			return;
-		}
-
-		$dk_variations        = $parent->get_meta( '1984_dk_woo_variations', true, 'edit' );
-		$dk_variant_code      = $parent->get_meta( '1984_dk_woo_variant_code', true, 'edit' );
-		$variation_attributes = ProductVariations::attributes_to_woocommerce_variation_attributes( $dk_variant_code );
-		$variation_codes      = array_keys( $variation_attributes );
-
-		if ( is_array( $dk_variations ) ) {
-			foreach ( $dk_variations as $dkv ) {
-				if (
-					strtolower( $product_variation->get_attribute( $variation_codes[0] ) ) === strtolower( $dkv->code_1 ) &&
-					strtolower( $product_variation->get_attribute( $variation_codes[1] ) ) === strtolower( $dkv->code_2 )
-				) {
-					$product_variation->set_manage_stock( $parent->get_manage_stock() );
-					$product_variation->set_stock_quantity( (float) $dkv->quantity );
-					$product_variation->save();
-					continue;
-				}
-			}
-		}
-	}
 }

--- a/src/Hooks/WooProductVariations.php
+++ b/src/Hooks/WooProductVariations.php
@@ -39,12 +39,67 @@ class WooProductVariations {
 			2
 		);
 
-		add_action(
-			'woocommerce_new_product_variation',
-			array( __CLASS__, 'set_stock_quantity_from_dk_variations' ),
+		add_filter(
+			'woocommerce_variation_option_name',
+			array( __CLASS__, 'filter_variation_option_name' ),
 			10,
-			2
+			1
 		);
+
+		add_filter(
+			'woocommerce_attribute_label',
+			array( __CLASS__, 'filter_variation_label' ),
+			10,
+			3
+		);
+
+		add_filter(
+			'woocommerce_order_item_display_meta_value',
+			array( __CLASS__, 'filter_woocommerce_order_meta_value' ),
+			10,
+			1
+		);
+	}
+
+	/**
+	 * Filter order meta values
+	 *
+	 * Filters displayed order meta, replacing attribute codes with their
+	 * names/descriptions.
+	 *
+	 * @param string $meta_value The meta value to filter.
+	 */
+	public static function filter_woocommerce_order_meta_value( string $meta_value ): string {
+		return ProductVariations::get_attribute_name( $meta_value );
+	}
+
+	/**
+	 * Filter variation labels
+	 *
+	 * Filters variation labels, replacing the reference code in DK with their
+	 * name/description if available.
+	 *
+	 * @param string $label The variation label.
+	 */
+	public static function filter_variation_label( string $label ): string {
+		$variation_attribute = ProductVariations::get_attribute( $label );
+		if ( ! $variation_attribute ) {
+			return $label;
+		}
+		return $variation_attribute->description;
+	}
+
+	/**
+	 * Filter variation option name
+	 *
+	 * Changes how variation attribute names appear in the drop down menu on
+	 * each product page, replacing the reference code from DK with its
+	 * name/description.
+	 *
+	 * @param string $name The variation name code.
+	 */
+	public static function filter_variation_option_name( string $name ): string {
+		return ProductVariations::get_attribute_name( $name );
 	}
 
 	/**

--- a/src/Hooks/WooProductVariations.php
+++ b/src/Hooks/WooProductVariations.php
@@ -115,6 +115,10 @@ class WooProductVariations {
 		$parent_id = $product_variation->get_parent_id();
 		$parent    = wc_get_product( $parent_id );
 
+		if ( ! $parent ) {
+			return;
+		}
+
 		if ( empty( $parent->get_sku() ) ) {
 			return;
 		}
@@ -152,6 +156,10 @@ class WooProductVariations {
 		$parent_id = $product_variation->get_parent_id();
 		$parent    = wc_get_product( $parent_id );
 
+		if ( ! $parent ) {
+			return;
+		}
+
 		$price = $parent->get_meta( '1984_dk_woo_price', true, 'edit' );
 
 		if ( is_object( $price ) ) {
@@ -176,6 +184,10 @@ class WooProductVariations {
 	): void {
 		$parent_id = $product_variation->get_parent_id();
 		$parent    = wc_get_product( $parent_id );
+
+		if ( ! $parent ) {
+			return;
+		}
 
 		$product_variation->update_meta_data(
 			'1984_dk_woo_origin',

--- a/src/Hooks/WooProductVariations.php
+++ b/src/Hooks/WooProductVariations.php
@@ -139,6 +139,12 @@ class WooProductVariations {
 		$product_variation->save();
 	}
 
+	/**
+	 * Set the variation price as the same as its parent
+	 *
+	 * @param int                  $id The variation ID (unused).
+	 * @param WC_Product_Variation $product_variation The variation object.
+	 */
 	public static function set_price_to_same_as_parent(
 		int $id,
 		WC_Product_Variation $product_variation
@@ -158,6 +164,12 @@ class WooProductVariations {
 		}
 	}
 
+	/**
+	 * Set the origin meta to the same as the parent product
+	 *
+	 * @param int                  $id The variation ID (unused).
+	 * @param WC_Product_Variation $product_variation The variation object.
+	 */
 	public static function set_origin_to_same_as_parent(
 		int $id,
 		WC_Product_Variation $product_variation

--- a/src/Hooks/WooUpdateProduct.php
+++ b/src/Hooks/WooUpdateProduct.php
@@ -54,11 +54,11 @@ class WooUpdateProduct {
 	 * Update product in DK when it is is updated in WooCommerce
 	 *
 	 * @param int        $id The product's post ID (not used).
-	 * @param WC_Product $product The WooCommrece product.
+	 * @param WC_Product $wc_product The WooCommrece product.
 	 */
 	public static function on_product_update(
 		int $id,
-		WC_Product $product
+		WC_Product $wc_product
 	): void {
 		if ( defined( 'DOING_CRON' ) ) {
 			return;
@@ -68,12 +68,12 @@ class WooUpdateProduct {
 			return;
 		}
 
-		if ( ! ProductHelper::should_sync( $product ) ) {
+		if ( ! ProductHelper::should_sync( $wc_product ) ) {
 			return;
 		}
 
 		// Create or update the product in DK.
-		ExportProduct::create_in_dk( $product );
+		ExportProduct::create_in_dk( $wc_product );
 	}
 
 	/**
@@ -94,6 +94,12 @@ class WooUpdateProduct {
 			return;
 		}
 
+		$wc_product = wc_get_product( $post_id );
+
+		if ( is_null( $wc_product ) || false === $wc_product ) {
+			return;
+		}
+
 		if (
 			in_array(
 				get_post_type( $post_id ),
@@ -101,8 +107,6 @@ class WooUpdateProduct {
 				true
 			)
 		) {
-			$wc_product = wc_get_product( $post_id );
-
 			if ( ! ProductHelper::should_sync( $wc_product ) ) {
 				return;
 			}
@@ -144,6 +148,10 @@ class WooUpdateProduct {
 		}
 
 		$wc_product = wc_get_product( $post->ID );
+
+		if ( is_null( $wc_product ) || false === $wc_product ) {
+			return;
+		}
 
 		if ( ! ProductHelper::should_sync( $wc_product ) ) {
 			return;

--- a/src/Hooks/WooUpdateProduct.php
+++ b/src/Hooks/WooUpdateProduct.php
@@ -94,7 +94,13 @@ class WooUpdateProduct {
 			return;
 		}
 
-		if ( 'product' === get_post_type( $post_id ) ) {
+		if (
+			in_array(
+				get_post_type( $post_id ),
+				array( 'product', 'product_variation' ),
+				true
+			)
+		) {
 			$wc_product = wc_get_product( $post_id );
 
 			if ( ! ProductHelper::should_sync( $wc_product ) ) {
@@ -126,11 +132,18 @@ class WooUpdateProduct {
 			return;
 		}
 
-		if ( 'product' !== get_post_type( $post ) ) {
+		if (
+			false ===
+			in_array(
+				get_post_type( $post ),
+				array( 'product', 'product_variation' ),
+				true
+			)
+		) {
 			return;
 		}
 
-		$wc_product = wc_get_product( $post );
+		$wc_product = wc_get_product( $post->ID );
 
 		if ( ! ProductHelper::should_sync( $wc_product ) ) {
 			return;
@@ -138,6 +151,9 @@ class WooUpdateProduct {
 
 		switch ( $new_status ) {
 			case 'draft':
+				ExportProduct::hide_from_webshop_in_dk( $wc_product );
+				break;
+			case 'private':
 				ExportProduct::hide_from_webshop_in_dk( $wc_product );
 				break;
 			case 'publish':

--- a/src/Hooks/WooUpdateProduct.php
+++ b/src/Hooks/WooUpdateProduct.php
@@ -68,6 +68,17 @@ class WooUpdateProduct {
 			return;
 		}
 
+		if ( is_null( $wc_product ) || false === $wc_product ) {
+			return;
+		}
+
+		if (
+			'product_variation' ===
+			$wc_product->get_meta( '1984_dk_woo_origin', true, 'edit' )
+		) {
+			return;
+		}
+
 		if ( ! ProductHelper::should_sync( $wc_product ) ) {
 			return;
 		}
@@ -97,6 +108,13 @@ class WooUpdateProduct {
 		$wc_product = wc_get_product( $post_id );
 
 		if ( is_null( $wc_product ) || false === $wc_product ) {
+			return;
+		}
+
+		if (
+			'product_variation' ===
+			$wc_product->get_meta( '1984_dk_woo_origin', true, 'edit' )
+		) {
 			return;
 		}
 
@@ -137,8 +155,7 @@ class WooUpdateProduct {
 		}
 
 		if (
-			false ===
-			in_array(
+			! in_array(
 				get_post_type( $post ),
 				array( 'product', 'product_variation' ),
 				true
@@ -150,6 +167,13 @@ class WooUpdateProduct {
 		$wc_product = wc_get_product( $post->ID );
 
 		if ( is_null( $wc_product ) || false === $wc_product ) {
+			return;
+		}
+
+		if (
+			'product_variation' ===
+			$wc_product->get_meta( '1984_dk_woo_origin', true, 'edit' )
+		) {
 			return;
 		}
 

--- a/src/Hooks/WooUpdateProduct.php
+++ b/src/Hooks/WooUpdateProduct.php
@@ -79,6 +79,13 @@ class WooUpdateProduct {
 			return;
 		}
 
+		if (
+			'product_variation' ===
+			$wc_product->get_meta( '1984_dk_woo_origin', true, 'edit' )
+		) {
+			return;
+		}
+
 		if ( ! ProductHelper::should_sync( $wc_product ) ) {
 			return;
 		}

--- a/src/Import/ProductVariations.php
+++ b/src/Import/ProductVariations.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace NineteenEightyFour\NineteenEightyWoo\Import;
+
+use NineteenEightyFour\NineteenEightyWoo\Service\DKApiRequest;
+use WC_Product;
+use WC_Product_Attribute;
+
+class ProductVariations {
+	const TRANSIENT_EXPIRY = 600;
+
+	const PRODUCTS_TABLE  = 'INITEMS.DAT';
+	const PRODUCTS_FIELDS = array( 'itemcode', 'variation' );
+
+	const VARIATIONS_TABLE  = 'INVAGR.DAT';
+	const VARIATIONS_FIELDS = array( 'recordid', 'code', 'description', 'subgroup1', 'subgroup2' );
+
+	const ATTRIBUTES_TABLE  = 'INVAHEAD.DAT';
+	const ATTRIBUTES_FIELDS = array( 'recordid', 'code', 'description' );
+
+	const VARIATION_ATTRIBUTES_TABLE  = 'INVALINE.DAT';
+	const VARIATION_ATTRIBUTES_FIELDS = array( 'headcode', 'description', 'headid', 'inactive' );
+
+	const ATTRIBUTE_VALUES_TABLE  = 'INVATEXT.DAT';
+	const ATTRIBUTE_VALUES_FIELDS = array( 'code', 'description' );
+
+	public static function attributes_to_woocommerce_variation_attributes(
+		string $code
+	): array {
+		if ( empty( $code ) ) {
+			return array();
+		}
+
+		$variations = self::get_variations();
+
+		$attributes = $variations[ $code ]->attributes;
+
+		$woocommerce_variation_attributes = array();
+
+		foreach ( $attributes as $code => $attribute ) {
+			$woocommerce_variation_attributes[ $code ] = array_keys( $attribute->values );
+		}
+
+		return $woocommerce_variation_attributes;
+	}
+
+	public static function variation_attributes_to_wc_product_attributes(
+		string $variation_code
+	): array {
+		$variations = self::get_variations();
+		$variation  = $variations[ $variation_code ];
+
+		$wc_attributes = array();
+
+		foreach ( $variation->attributes as $v ) {
+			$wc_product_attribute = new WC_Product_Attribute();
+			$wc_product_attribute->set_name( $v->code );
+			$wc_product_attribute->set_options( array_keys( $v->values ) );
+			$wc_product_attribute->set_visible( true );
+			$wc_product_attribute->set_variation( true );
+
+			$wc_attributes[] = $wc_product_attribute;
+		}
+
+		return array_reverse( $wc_attributes );
+	}
+
+	public static function get_product_variant_code_by_sku( string $sku ) {
+		$request = new DKApiRequest();
+
+		$result = $request->get_table_result(
+			self::PRODUCTS_TABLE,
+			self::PRODUCTS_FIELDS,
+			'itemcode',
+			$sku
+		);
+
+		if ( 200 === $result->response_code ) {
+			return $result->data[0]->VARIATION;
+		}
+
+		return '';
+	}
+
+	public static function get_product_skus_by_variation( string $variation ) {
+		$product_skus_by_variation_transient = get_transient(
+			'1984_woo_dk_product_skus_by_variation_' . $variation
+		);
+
+		if ( is_array( $product_skus_by_variation_transient ) ) {
+			return $product_skus_by_variation_transient;
+		}
+
+		$product_skus_by_variation_value = self::get_product_skus_by_variation_from_dk( $variation );
+
+		if ( is_array( $product_skus_by_variation_value ) ) {
+			set_transient(
+				'1984_woo_dk_product_skus_by_variation_' . $variation,
+				$product_skus_by_variation_value,
+				self::TRANSIENT_EXPIRY
+			);
+
+			return $product_skus_by_variation_value;
+		}
+
+		return array();
+	}
+
+	public static function get_product_skus_by_variation_from_dk( string $variation ) {
+		$request = new DKApiRequest();
+
+		$result = $request->get_table_result(
+			self::PRODUCTS_TABLE,
+			self::PRODUCTS_FIELDS,
+			'variation',
+			$variation
+		);
+
+		if ( 200 === $result->response_code ) {
+			return array_column( $result->data, 'ITEMCODE' );
+		}
+
+		return array();
+	}
+
+	public static function get_variations() {
+		$variations_transient = get_transient(
+			'1984_woo_dk_variations'
+		);
+
+		if ( is_array( $variations_transient ) ) {
+			return $variations_transient;
+		}
+
+		$variations_value = self::get_variations_from_dk();
+
+		if ( $variations_value ) {
+			set_transient(
+				'1984_woo_dk_variations',
+				$variations_value,
+				self::TRANSIENT_EXPIRY
+			);
+
+			return $variations_value;
+		}
+
+		return false;
+	}
+
+	public static function get_variations_from_dk() {
+		$request = new DKApiRequest();
+
+		$result = $request->get_table_result(
+			self::VARIATIONS_TABLE,
+			self::VARIATIONS_FIELDS
+		);
+
+		if ( 200 === $result->response_code ) {
+			return self::parse_variations_json( $result->data );
+		}
+
+		return false;
+	}
+
+	public static function get_attribute( string $code ) {
+		$attribute_transient = get_transient(
+			'1984_woo_dk_attribute_' . $code
+		);
+
+		if ( is_object( $attribute_transient ) ) {
+			return $attribute_transient;
+		}
+
+		$attribute_value = self::get_attribute_from_dk( $code );
+
+		if ( $attribute_value ) {
+			set_transient(
+				'1984_woo_dk_attribute_' . $code,
+				$attribute_value,
+				self::TRANSIENT_EXPIRY
+			);
+
+			return $attribute_value;
+		}
+
+		return false;
+	}
+
+	public static function get_attribute_from_dk( string $code ) {
+		$request = new DKApiRequest();
+
+		$result = $request->get_table_result(
+			self::ATTRIBUTES_TABLE,
+			self::ATTRIBUTES_FIELDS,
+			'code',
+			$code
+		);
+
+		if ( empty( $result->data ) ) {
+			return false;
+		}
+
+		if ( 200 === $result->response_code ) {
+			$object      = $result->data[0];
+			$description = (string) $object->DESCRIPTION;
+			$record_id   = (int) $object->RECORDID;
+			$code        = $object->CODE;
+			return (object) array(
+				'id'          => $record_id,
+				'code'        => $code,
+				'description' => $description,
+				'values'      => self::get_variation_attributes( $record_id ),
+			);
+		}
+
+		return false;
+	}
+
+	public static function get_variation_attributes( int $variation_id ) {
+		$variation_attributes_transient = get_transient(
+			'1984_woo_dk_variation_attributes_' . (string) $variation_id
+		);
+
+		if ( is_array( $variation_attributes_transient ) ) {
+			return $variation_attributes_transient;
+		}
+
+		$variation_attributes_values = self::get_variation_attributes_from_dk( $variation_id );
+
+		if ( is_array( $variation_attributes_values ) ) {
+			set_transient(
+				'1984_woo_dk_variation_attributes_' . (string) $variation_id,
+				$variation_attributes_values,
+				self::TRANSIENT_EXPIRY
+			);
+
+			return $variation_attributes_values;
+		}
+
+		return array();
+	}
+
+	public static function get_variation_attributes_from_dk( int $variation_id ) {
+		$values  = self::get_attribute_values();
+		$request = new DKApiRequest();
+
+		$result = $request->get_table_result(
+			self::VARIATION_ATTRIBUTES_TABLE,
+			self::VARIATION_ATTRIBUTES_FIELDS,
+			'headid',
+			(string) $variation_id
+		);
+
+		if ( 200 === $result->response_code ) {
+			$attributes = array();
+
+			foreach ( $result->data as $a ) {
+				if ( 'true' === $a->INACTIVE ) {
+					continue;
+				}
+
+				$code     = $a->HEADCODE;
+				$code_key = strtoupper( $code );
+
+				$attributes[ $code ] = (object) array(
+					'code' => $code,
+					'name' => $values[ $code_key ]->name,
+				);
+			}
+
+			return $attributes;
+		}
+
+		return array();
+	}
+
+	public static function get_attribute_values() {
+		$attribute_values_transient = get_transient(
+			'1984_woo_dk_attribute_values'
+		);
+
+		if ( is_array( $attribute_values_transient ) ) {
+			return $attribute_values_transient;
+		}
+
+		$attribute_values = self::get_attribute_values_from_dk();
+
+		if ( is_array( $attribute_values ) ) {
+			set_transient(
+				'1984_woo_dk_attribute_values',
+				$attribute_values,
+				self::TRANSIENT_EXPIRY
+			);
+
+			return $attribute_values;
+		}
+
+		return array();
+	}
+
+	public static function get_attribute_name( $code ) {
+		$attribute_values = self::get_attribute_values();
+
+		$key = strtoupper( $code );
+
+		if ( ! key_exists( $key, $attribute_values ) ) {
+			return $code;
+		}
+
+		if ( ! property_exists( $attribute_values[ $key ], 'name' ) ) {
+			return $code;
+		}
+
+		return $attribute_values[ $key ]->name;
+	}
+
+	public static function get_attribute_values_from_dk() {
+		$request = new DKApiRequest();
+
+		$result = $request->get_table_result(
+			self::ATTRIBUTE_VALUES_TABLE,
+			self::ATTRIBUTE_VALUES_FIELDS,
+		);
+
+		if ( 200 === $result->response_code ) {
+			$values = array();
+
+			foreach ( $result->data as $v ) {
+				$code = $v->CODE;
+
+				if ( property_exists( $v, 'DESCRIPTION' ) ) {
+					$name = $v->DESCRIPTION;
+				} else {
+					$name = $code;
+				}
+
+				$values[ $code ] = (object) array(
+					'code' => $code,
+					'name' => $name,
+				);
+			}
+
+			return $values;
+		}
+
+		return array();
+	}
+
+	public static function parse_variations_json( $variation_json ): array {
+		$variations = array();
+
+		foreach ( $variation_json as $vj ) {
+			$code        = $vj->CODE;
+			$description = $vj->DESCRIPTION;
+			$attribute_1 = $vj->SUBGROUP1;
+			$attribute_2 = $vj->SUBGROUP2;
+
+			$variations[ $code ] = (object) array(
+				'code'        => $code,
+				'description' => $description,
+				'attributes'  => array(
+					$attribute_1 => self::get_attribute( $attribute_1 ),
+					$attribute_2 => self::get_attribute( $attribute_2 ),
+				),
+			);
+		}
+
+		return $variations;
+	}
+}

--- a/src/Import/ProductVariations.php
+++ b/src/Import/ProductVariations.php
@@ -352,19 +352,24 @@ class ProductVariations {
 		$variations = array();
 
 		foreach ( $variation_json as $vj ) {
+			$variation   = array();
 			$code        = $vj->CODE;
 			$description = $vj->DESCRIPTION;
-			$attribute_1 = $vj->SUBGROUP1;
-			$attribute_2 = $vj->SUBGROUP2;
 
-			$variations[ $code ] = (object) array(
+			$variations[ $code ] = array(
 				'code'        => $code,
 				'description' => $description,
-				'attributes'  => array(
-					$attribute_1 => self::get_attribute( $attribute_1 ),
-					$attribute_2 => self::get_attribute( $attribute_2 ),
-				),
 			);
+
+			if ( property_exists( $vj, 'SUBGROUP1' ) ) {
+				$variation['attributes'][ $vj->SUBGROUP1 ] = self::get_attribute( $vj->SUBGROUP1 );
+			}
+
+			if ( property_exists( $vj, 'SUBGROUP2' ) ) {
+				$variation['attributes'][ $vj->SUBGROUP2 ] = self::get_attribute( $vj->SUBGROUP2 );
+			}
+
+			$variations[ $code ] = (object) $variation;
 		}
 
 		return $variations;

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -16,6 +16,7 @@ use WC_DateTime;
 use WC_Product;
 use WP_Error;
 use WC_Tax;
+use WC_Product_Variation;
 
 /**
  * The Products import class
@@ -329,7 +330,11 @@ class Products {
 		if ( true === $json_object->ShowItemInWebShop ) {
 			$wc_product->set_status( 'Publish' );
 		} else {
-			$wc_product->set_status( 'Draft' );
+			if ( $wc_product instanceof WC_Product_Variation ) {
+				$wc_product->set_status( 'Private' );
+			} else {
+				$wc_product->set_status( 'Draft' );
+			}
 		}
 
 		if (

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -230,6 +230,7 @@ class Products {
 
 		if ( true === $json_object->IsVariation ) {
 			$wc_product = wc_get_product_object( 'variable' );
+			$wc_product->save();
 
 			$variant_code = ProductVariations::get_product_variant_code_by_sku(
 				$json_object->ItemCode
@@ -258,6 +259,7 @@ class Products {
 			self::update_variations( $merged_variations, $wc_product );
 		} else {
 			$wc_product = wc_get_product_object( 'simple' );
+			$wc_product->save();
 			$wc_product->update_meta_data( '1984_dk_woo_origin', 'product' );
 		}
 

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -258,7 +258,6 @@ class Products {
 			$wc_product->update_meta_data( '1984_dk_woo_origin', 'product' );
 			$wc_product->update_meta_data( '1984_dk_woo_variant_code', '' );
 			$wc_product->update_meta_data( '1984_dk_woo_variations', '' );
-			$wc_product->set_attributes( array() );
 		}
 
 		if ( ! $json_object->ShowItemInWebShop ) {
@@ -348,6 +347,21 @@ class Products {
 	): WC_Product|false {
 		$wc_product = wc_get_product( $product_id );
 
+		if ( ! ( $wc_product instanceof WC_Product ) ) {
+			return false;
+		}
+
+		if (
+			$json_object->Inactive ||
+			(
+				property_exists( $json_object, 'Deleted' ) &&
+				true === $json_object->Deleted
+			)
+		) {
+			wp_delete_post( $wc_product->get_id() );
+			return false;
+		}
+
 		if ( true === $json_object->IsVariation ) {
 			$variant_code = ProductVariations::get_product_variant_code_by_sku(
 				$json_object->ItemCode
@@ -373,23 +387,8 @@ class Products {
 			$wc_product->update_meta_data( '1984_dk_woo_origin', 'product' );
 			$wc_product->update_meta_data( '1984_dk_woo_variant_code', '' );
 			$wc_product->update_meta_data( '1984_dk_woo_variations', '' );
-			$wc_product->set_attributes( array() );
 		}
 
-		if ( ! ( $wc_product instanceof WC_Product ) ) {
-			return false;
-		}
-
-		if (
-			$json_object->Inactive ||
-			(
-				property_exists( $json_object, 'Deleted' ) &&
-				true === $json_object->Deleted
-			)
-		) {
-			wp_delete_post( $wc_product->get_id() );
-			return false;
-		}
 
 		if ( true === $json_object->ShowItemInWebShop ) {
 			$wc_product->set_status( 'Publish' );

--- a/src/Service/DKApiRequest.php
+++ b/src/Service/DKApiRequest.php
@@ -89,6 +89,32 @@ class DKApiRequest {
 		return $this->parse_wp_http_response( $request );
 	}
 
+	public function get_table_result(
+		string $table,
+		array $fields,
+		?string $key = null,
+		?string $keyvalue = null
+	): WP_Error|stdClass {
+		$path = self::DK_API_URL . '/general/table/' . $table . '/records/';
+
+		$fields_string = implode( ',', $fields );
+		$query_string  = "?fields=$fields_string";
+
+		if ( ! empty( $key ) && ! empty( $keyvalue ) ) {
+			$query_string .= "&key=$key&value=$keyvalue";
+		}
+
+		$request = $this->wp_http->get(
+			$path . $query_string,
+			array(
+				'httpversion' => '1.1',
+				'headers'     => $this->get_headers,
+			),
+		);
+
+		return $this->parse_wp_http_response( $request );
+	}
+
 	/**
 	 * Send a resource modifying request to the DK API
 	 *

--- a/src/Service/DKApiRequest.php
+++ b/src/Service/DKApiRequest.php
@@ -89,6 +89,14 @@ class DKApiRequest {
 		return $this->parse_wp_http_response( $request );
 	}
 
+	/**
+	 * Get a result directly from a DK table
+	 *
+	 * @param string $table The DK table to check.
+	 * @param array  $fields The names of the fields to get.
+	 * @param string $key The key to use for filtering (i.e. WHERE $key = $keyvalue).
+	 * @param string $keyvalue They value to use for filtering.
+	 */
 	public function get_table_result(
 		string $table,
 		array $fields,

--- a/style/products.css
+++ b/style/products.css
@@ -1,0 +1,3 @@
+input#action_post_id_input {
+	width: 7em;
+}

--- a/views/admin.php
+++ b/views/admin.php
@@ -122,7 +122,7 @@ use NineteenEightyFour\NineteenEightyWoo\Hooks\KennitalaField;
 								<?php esc_html_e( 'Sync Product Names with DK', '1984-dk-woo' ); ?>
 							</label>
 							<p class="description">
-								<?php esc_html_e( 'If enabled, product names are synced between DK and WooCommerce. Disable this if you would like to be able to use separate product names in your WooCommerce shop from the ones in DK.', '1984-dk-woo' ); ?>
+								<?php esc_html_e( 'If enabled, product names are synced between DK and WooCommerce. Disable this if you would like to be able to use separate product names in your WooCommerce shop from the ones in DK or simply prevent WooCommerce from affecting product descriptions in DK.', '1984-dk-woo' ); ?>
 							</p>
 						</td>
 					</tr>


### PR DESCRIPTION
- The plugin now supports the DK variant module (I just found out that it is a thing last week)
- Variations are synced between DK and WooCommerce (WooCommerce Variants are created and deleted on sync)
- Variants can also be generated from products in the UI — those are not indicated as variants in DK

https://github.com/user-attachments/assets/6f0373f9-4906-4067-b35b-0f53bdc5b18a

