### PR TITLE
Stretching the expected response time from the DK API

### DIFF
--- a/src/Service/DKApiRequest.php
+++ b/src/Service/DKApiRequest.php
@@ -15,7 +15,9 @@ use WP_Http;
  * Handles the low-level HTTP requests to the DK JSON API.
  */
 class DKApiRequest {
-	const DK_API_URL = 'https://api.dkplus.is/api/v1';
+	const DK_API_URL   = 'https://api.dkplus.is/api/v1';
+	const GET_TIMEOUT  = 10.0;
+	const POST_TIMEOUT = 15.0;
 
 	/**
 	 * The DK API key
@@ -83,6 +85,7 @@ class DKApiRequest {
 			array(
 				'httpversion' => '1.1',
 				'headers'     => $this->get_headers,
+				'timeout'     => self::GET_TIMEOUT,
 			),
 		);
 
@@ -117,6 +120,7 @@ class DKApiRequest {
 			array(
 				'httpversion' => '1.1',
 				'headers'     => $this->get_headers,
+				'timeout'     => self::GET_TIMEOUT,
 			),
 		);
 
@@ -155,6 +159,7 @@ class DKApiRequest {
 				'httpversion' => '1.1',
 				'headers'     => $this->post_headers,
 				'body'        => $body,
+				'timeout'     => self::POST_TIMEOUT,
 			),
 		);
 


### PR DESCRIPTION
It seems like during peak periods that DK is not responding to invoice generation requests in time. This stretches the timeout to 10 seconds for GET requests and 15 seconds for POST requests, with is 2x and 3x the default of 5 seconds.