### PR TITLE
Using the PosInvoice field to store the WooCommerce order number in DK

### DIFF
--- a/src/Export/Invoice.php
+++ b/src/Export/Invoice.php
@@ -233,6 +233,7 @@ class Invoice {
 	): array {
 		$invoice_body = ExportOrder::to_dk_order_body( $wc_order );
 
+		$invoice_body['PosInvoice']  = $wc_order->get_id();
 		$invoice_body['SalesPerson'] = Config::get_default_sales_person_number();
 
 		$payment_mapping = Config::get_payment_mapping(

--- a/src/Export/Order.php
+++ b/src/Export/Order.php
@@ -128,8 +128,6 @@ class Order {
 		$recipient_array = array();
 		$customer_array  = array( 'Number' => $kennitala );
 
-		$order_props['Reference'] = 'WC-' . $wc_order->get_id();
-
 		$recipient_array['Name']     = $wc_order->get_formatted_billing_full_name();
 		$recipient_array['Address1'] = $wc_order->get_shipping_address_1();
 		$recipient_array['Address2'] = $wc_order->get_shipping_address_2();


### PR DESCRIPTION
This replaces the Reference field, which seems to have a different purpose.