### PR TITLE
Adding the DK invoice column to the legacy order table

### DIFF
--- a/style/admin.css
+++ b/style/admin.css
@@ -172,21 +172,21 @@ body.woocommerce_page_1984-dk-woo .wrap {
 	display: none;
 }
 
-.wc-orders-list-table .column-dk_invoice_id .dashicons {
+table .column-dk_invoice_id .dashicons {
 	padding: 4px 0px 4px 4px;
 }
 
-.wc-orders-list-table .column-dk_invoice_id .debit_invoice {
+table .column-dk_invoice_id .debit_invoice {
 	color: rgb(0, 120, 60);
 	font-weight: 600;
 }
 
-.wc-orders-list-table .column-dk_invoice_id .credit_invoice {
+table .column-dk_invoice_id .credit_invoice {
 	color: #333;
 	font-weight: 600;
 }
 
-.wc-orders-list-table .column-dk_invoice_id .invoice_error {
+table .column-dk_invoice_id .invoice_error {
 	color: #900;
 	font-weight: 600;
 }


### PR DESCRIPTION
When using the posts table to store orders, different actions and filters are used than in the new "High-performance order storage", which is currently the default way to store orders.

This uses those "legacy" hooks display the DK invoice number.