### PR TITLE
Using case-insensitive string comparisons using mb_strtolower

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -38,7 +38,7 @@ class Currency {
 			return self::invalid_currency_code_error( $currency );
 		}
 
-		$option_name = '1984_woo_dk_currency_rate_' . strtolower( $currency );
+		$option_name = '1984_woo_dk_currency_rate_' . mb_strtolower( $currency );
 
 		$float_value = (float) $rate;
 
@@ -62,7 +62,7 @@ class Currency {
 			return self::invalid_currency_code_error( $currency );
 		}
 
-		$option_name = '1984_woo_dk_currency_rate_' . strtolower( $currency );
+		$option_name = '1984_woo_dk_currency_rate_' . mb_strtolower( $currency );
 
 		$rate = get_option( $option_name, 0 );
 
@@ -105,7 +105,7 @@ class Currency {
 		}
 
 		$from_rate = get_option(
-			'1984_woo_dk_currency_rate_' . strtolower( $from ),
+			'1984_woo_dk_currency_rate_' . mb_strtolower( $from ),
 		);
 
 		if ( ! $from_rate ) {
@@ -124,7 +124,7 @@ class Currency {
 		}
 
 		$to_rate = get_option(
-			'1984_woo_dk_currency_rate_' . strtolower( $to )
+			'1984_woo_dk_currency_rate_' . mb_strtolower( $to )
 		);
 
 		if ( ! $to_rate ) {

--- a/src/Import/ProductVariations.php
+++ b/src/Import/ProductVariations.php
@@ -87,14 +87,16 @@ class ProductVariations {
 			return array();
 		}
 
+		$lower_case_code = mb_strtolower( $code );
+
 		$variations = self::get_variations();
 
-		$attributes = $variations[ $code ]->attributes;
+		$attributes = $variations[ $lower_case_code ]->attributes;
 
 		$woocommerce_variation_attributes = array();
 
 		foreach ( $attributes as $code => $attribute ) {
-			$woocommerce_variation_attributes[ strtolower( $code ) ] = array_keys(
+			$woocommerce_variation_attributes[ $lower_case_code ] = array_keys(
 				$attribute->values
 			);
 		}
@@ -313,7 +315,7 @@ class ProductVariations {
 			$code        = $object->CODE;
 			return (object) array(
 				'id'          => $record_id,
-				'code'        => strtolower( $code ),
+				'code'        => mb_strtolower( $code ),
 				'description' => $description,
 				'values'      => self::get_variation_attributes( $record_id ),
 			);
@@ -381,8 +383,8 @@ class ProductVariations {
 			$attributes = array();
 
 			foreach ( $result->data as $a ) {
-				$code     = strtolower( $a->HEADCODE );
-				$code_key = strtolower( $code );
+				$code     = mb_strtolower( $a->HEADCODE );
+				$code_key = mb_strtolower( $code );
 
 				$attributes[ $code ] = (object) array(
 					'code' => $code,
@@ -406,7 +408,7 @@ class ProductVariations {
 	public static function get_attribute_name( string $code ): string {
 		$attribute_values = self::get_attribute_values();
 
-		$key = strtolower( $code );
+		$key = mb_strtolower( $code );
 
 		if ( ! key_exists( $key, $attribute_values ) ) {
 			return $code;
@@ -469,8 +471,8 @@ class ProductVariations {
 					$name = $code;
 				}
 
-				$values[ strtolower( $code ) ] = (object) array(
-					'code' => strtolower( $code ),
+				$values[ mb_strtolower( $code ) ] = (object) array(
+					'code' => mb_strtolower( $code ),
 					'name' => $name,
 				);
 			}
@@ -491,7 +493,7 @@ class ProductVariations {
 
 		foreach ( $variation_json as $vj ) {
 			$variation   = array();
-			$code        = strtolower( $vj->CODE );
+			$code        = mb_strtolower( $vj->CODE );
 			$description = $vj->DESCRIPTION;
 
 			$variation['skus'] = self::get_product_skus_by_variation_from_dk(
@@ -499,18 +501,18 @@ class ProductVariations {
 			);
 
 			$variations[ $code ] = array(
-				'code'        => strtolower( $code ),
+				'code'        => mb_strtolower( $code ),
 				'description' => $description,
 			);
 
 			if ( property_exists( $vj, 'SUBGROUP1' ) ) {
-				$variation['attributes'][ strtolower( $vj->SUBGROUP1 ) ] =
-				self::get_attribute( strtolower( $vj->SUBGROUP1 ) );
+				$variation['attributes'][ mb_strtolower( $vj->SUBGROUP1 ) ] =
+				self::get_attribute( mb_strtolower( $vj->SUBGROUP1 ) );
 			}
 
 			if ( property_exists( $vj, 'SUBGROUP2' ) ) {
-				$variation['attributes'][ strtolower( $vj->SUBGROUP2 ) ] =
-				self::get_attribute( strtolower( $vj->SUBGROUP2 ) );
+				$variation['attributes'][ mb_strtolower( $vj->SUBGROUP2 ) ] =
+				self::get_attribute( mb_strtolower( $vj->SUBGROUP2 ) );
 			}
 
 			$variations[ $code ] = (object) $variation;

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -215,15 +215,24 @@ class Products {
 			return false;
 		}
 
-		if ( strtolower( Config::get_shipping_sku() ) === strtolower( $json_object->ItemCode ) ) {
+		if (
+			mb_strtolower( Config::get_shipping_sku() ) ===
+			mb_strtolower( $json_object->ItemCode )
+		) {
 			return false;
 		}
 
-		if ( strtolower( Config::get_cost_sku() ) === strtolower( $json_object->ItemCode ) ) {
+		if (
+			mb_strtolower( Config::get_cost_sku() ) ===
+			mb_strtolower( $json_object->ItemCode )
+		) {
 			return false;
 		}
 
-		if ( ! $json_object->ShowItemInWebShop && ! Config::get_import_nonweb_products() ) {
+		if (
+			! $json_object->ShowItemInWebShop &&
+			! Config::get_import_nonweb_products()
+		) {
 			return false;
 		}
 
@@ -730,13 +739,13 @@ class Products {
 				}
 				$variation = array(
 					'quantity'    => (float) $v->Quantity,
-					'attribute_1' => strtolower( $attribute_names[0] ),
-					'code_1'      => strtolower( $v->Code ),
+					'attribute_1' => mb_strtolower( $attribute_names[0] ),
+					'code_1'      => mb_strtolower( $v->Code ),
 				);
 
 				if ( property_exists( $v, 'Code2' ) ) {
-					$variation['attribute_2'] = strtolower( $attribute_names[1] );
-					$variation['code_2']      = strtolower( $v->Code2 );
+					$variation['attribute_2'] = mb_strtolower( $attribute_names[1] );
+					$variation['code_2']      = mb_strtolower( $v->Code2 );
 				}
 
 				$variations_array[] = (object) $variation;


### PR DESCRIPTION
This replaces `strtolower`, which does not support unicode. DK seems to allow any letter and symbol in various codes and references (including variations).

This fixes an issue where variations did not end up in invoice exports, as a comparison conditional was failing.