### PR TITLE
Fixes fatal error if $post is empty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,8 +70,8 @@
             "Composer\\Config::disableProcessTimeout",
             "docker exec -it $(docker-compose ps -q | head -n 1) tail -f /tmp/wp-errors.log"
         ],
-        "lint": "./vendor/bin/phpcs -s ./src/ ./js/ ./style/",
-        "lint:fix": "./vendor/bin/phpcbf -s ./src/ ./js/ ./style/",
+        "lint": "./vendor/bin/phpcs -s ./src/ ./js/ ./style/ ./views/",
+        "lint:fix": "./vendor/bin/phpcbf -s ./src/ ./js/ ./style/ ./views/",
         "zip:release": "rm -rf vendor/ && composer install --no-dev && cd .. && zip -r 1984-connector-for-dk-and-woocommerce.zip 1984-connector-for-dk-and-woocommerce -i 1984-connector-for-dk-and-woocommerce/languages/\\*.php -i 1984-connector-for-dk-and-woocommerce/languages/\\*.mo -i 1984-connector-for-dk-and-woocommerce/languages/\\*.po -i 1984-connector-for-dk-and-woocommerce/languages/\\*.pot -i 1984-connector-for-dk-and-woocommerce/languages/\\*.json -i 1984-connector-for-dk-and-woocommerce/src/\\* -i 1984-connector-for-dk-and-woocommerce/vendor/\\* -i 1984-connector-for-dk-and-woocommerce/views/\\* -i 1984-connector-for-dk-and-woocommerce/js/\\* -i 1984-connector-for-dk-and-woocommerce/style/\\* -i 1984-connector-for-dk-and-woocommerce/*.php -i 1984-connector-for-dk-and-woocommerce/*.txt -i 1984-connector-for-dk-and-woocommerce/assets/\\* -i 1984-connector-for-dk-and-woocommerce/composer.* -i 1984-connector-for-dk-and-woocommerce/*.xml -i 1984-connector-for-dk-and-woocommerce/readme.txt -i 1984-connector-for-dk-and-woocommerce/json_schemas/*.json"
     }
 }

--- a/views/dk_invoice_metabox.php
+++ b/views/dk_invoice_metabox.php
@@ -8,170 +8,164 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-global $post;
-if ( ! empty( $post ) ) {
-	$wc_order = wc_get_order( $post->ID );
+$wc_order = wc_get_order();
 
-	$invoice_number        = $wc_order->get_meta( '1984_woo_dk_invoice_number', true, 'edit' );
-	$credit_invoice_number = $wc_order->get_meta( '1984_woo_dk_credit_invoice_number', true, 'edit' );
-
-	?>
-
-  <div
-	class="input-set"
-	aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
-  >
-	<div class="input">
-	  <label
-		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
-		for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-	  >
-		<?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
-	  </label>
-	  <input
-		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-		class="regular-text"
-		aria-live="polite"
-		name="1984_woo_dk_invoice_number"
-		type="text"
-		autocomplete="off"
-		value="<?php echo esc_attr( $invoice_number ); ?>"
-	  />
-	  <div class="errors" aria-live="polite">
-		<p
-		  id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
-		  class="infotext error hidden"
-		>
-		  <span class="dashicons dashicons-no"></span>
-		  <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-		</p>
-	  </div>
-	</div>
-	<div class="buttons">
-	  <button
-		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
-		class="button button-small button-secondary"
-		title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
-		<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-	  >
-		<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-	  </button>
-	  <button
-		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
-		class="button button-small button-primary"
-		title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
-		<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-	  >
-		<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-	  </button>
-	  <?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
-		<button
-		  id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
-		  class="button button-small button-primary"
-		  title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
-			<?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
-		>
-			<?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
-		</button>
-	  <?php endif ?>
-	  <img
-		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
-		class="loader hidden"
-		src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-		width="16"
-		height="16"
-	  />
-	</div>
-	<div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
-	  <p
-		id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
-		class="infotext ok hidden"
-	  >
-		<span class="dashicons dashicons-yes"></span>
-		<?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
-	  </p>
-	  <p
-		id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
-		class="infotext error hidden"
-	  >
-		<span class="dashicons dashicons-no"></span>
-		<?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
-	  </p>
-	  <p
-		id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
-		class="infotext ok hidden"
-	  >
-		<span class="dashicons dashicons-yes"></span>
-		<?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
-	  </p>
-	  <p
-		id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
-		class="infotext error hidden"
-	  >
-		<span class="dashicons dashicons-yes"></span>
-		<?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
-	  </p>
-	  <p
-		id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
-		class="infotext error hidden"
-	  >
-		<span class="dashicons dashicons-no"></span>
-		<?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
-	  </p>
-	</div>
-  </div>
-
-  <div class="input-set">
-	<div class="input">
-	  <label
-		for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-	  >
-		<?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
-	  </label>
-	  <input
-		id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-		class="regular-text"
-		name="1984_woo_dk_credit_invoice_number"
-		type="text"
-		autocomplete="off"
-		value="<?php echo esc_attr( $credit_invoice_number ); ?>"
-	  />
-	  <div class="errors" aria-live="polite">
-		<p
-		  id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
-		  class="infotext error hidden"
-		>
-		  <span class="dashicons dashicons-no"></span>
-		  <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-		</p>
-	  </div>
-	</div>
-	<div class="buttons">
-	  <button
-		id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
-		class="button button-small button-secondary"
-		title="Update the credit invoice number reference without generating a new credit invoice in DK"
-		<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-	  >
-		<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-	  </button>
-	  <button
-		id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
-		class="button button-small button-primary"
-		title="Get the credit invoice as a PDF file"
-		<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-	  >
-		<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-	  </button>
-	  <img
-		id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
-		class="loader hidden"
-		src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-		width="16"
-		height="16"
-	  />
-	</div>
-  </div>
-	<?php
-}
+$invoice_number        = $wc_order->get_meta( '1984_woo_dk_invoice_number', true, 'edit' );
+$credit_invoice_number = $wc_order->get_meta( '1984_woo_dk_credit_invoice_number', true, 'edit' );
 ?>
+
+<div
+class="input-set"
+aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+>
+<div class="input">
+	<label
+	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+	for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+	>
+	<?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
+	</label>
+	<input
+	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+	class="regular-text"
+	aria-live="polite"
+	name="1984_woo_dk_invoice_number"
+	type="text"
+	autocomplete="off"
+	value="<?php echo esc_attr( $invoice_number ); ?>"
+	/>
+	<div class="errors" aria-live="polite">
+	<p
+		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
+		class="infotext error hidden"
+	>
+		<span class="dashicons dashicons-no"></span>
+		<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+	</p>
+	</div>
+</div>
+<div class="buttons">
+	<button
+	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
+	class="button button-small button-secondary"
+	title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
+	<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+	>
+	<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+	</button>
+	<button
+	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
+	class="button button-small button-primary"
+	title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
+	<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+	>
+	<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+	</button>
+	<?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
+	<button
+		id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
+		class="button button-small button-primary"
+		title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
+		<?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
+	>
+		<?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
+	</button>
+	<?php endif ?>
+	<img
+	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
+	class="loader hidden"
+	src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+	width="16"
+	height="16"
+	/>
+</div>
+<div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
+	<p
+	id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
+	class="infotext ok hidden"
+	>
+	<span class="dashicons dashicons-yes"></span>
+	<?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
+	</p>
+	<p
+	id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
+	class="infotext error hidden"
+	>
+	<span class="dashicons dashicons-no"></span>
+	<?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
+	</p>
+	<p
+	id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
+	class="infotext ok hidden"
+	>
+	<span class="dashicons dashicons-yes"></span>
+	<?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
+	</p>
+	<p
+	id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
+	class="infotext error hidden"
+	>
+	<span class="dashicons dashicons-yes"></span>
+	<?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
+	</p>
+	<p
+	id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
+	class="infotext error hidden"
+	>
+	<span class="dashicons dashicons-no"></span>
+	<?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
+	</p>
+</div>
+</div>
+
+<div class="input-set">
+<div class="input">
+	<label
+	for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+	>
+	<?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
+	</label>
+	<input
+	id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+	class="regular-text"
+	name="1984_woo_dk_credit_invoice_number"
+	type="text"
+	autocomplete="off"
+	value="<?php echo esc_attr( $credit_invoice_number ); ?>"
+	/>
+	<div class="errors" aria-live="polite">
+	<p
+		id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
+		class="infotext error hidden"
+	>
+		<span class="dashicons dashicons-no"></span>
+		<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+	</p>
+	</div>
+</div>
+<div class="buttons">
+	<button
+	id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
+	class="button button-small button-secondary"
+	title="Update the credit invoice number reference without generating a new credit invoice in DK"
+	<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+	>
+	<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+	</button>
+	<button
+	id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
+	class="button button-small button-primary"
+	title="Get the credit invoice as a PDF file"
+	<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+	>
+	<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+	</button>
+	<img
+	id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
+	class="loader hidden"
+	src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+	width="16"
+	height="16"
+	/>
+</div>
+</div>

--- a/views/dk_invoice_metabox.php
+++ b/views/dk_invoice_metabox.php
@@ -5,170 +5,173 @@ declare(strict_types = 1);
 use NineteenEightyFour\NineteenEightyWoo\Helpers\Order as OrderHelper;
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+  exit;
 }
 
 global $post;
+if(!empty($post)) {
+  $wc_order = wc_get_order( $post->ID );
 
-$wc_order = wc_get_order( $post->ID );
+  $invoice_number        = $wc_order->get_meta( '1984_woo_dk_invoice_number', true, 'edit' );
+  $credit_invoice_number = $wc_order->get_meta( '1984_woo_dk_credit_invoice_number', true, 'edit' );
 
-$invoice_number        = $wc_order->get_meta( '1984_woo_dk_invoice_number', true, 'edit' );
-$credit_invoice_number = $wc_order->get_meta( '1984_woo_dk_credit_invoice_number', true, 'edit' );
+  ?>
 
+  <div
+    class="input-set"
+    aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+  >
+    <div class="input">
+      <label
+        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+        for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+      >
+        <?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
+      </label>
+      <input
+        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+        class="regular-text"
+        aria-live="polite"
+        name="1984_woo_dk_invoice_number"
+        type="text"
+        autocomplete="off"
+        value="<?php echo esc_attr( $invoice_number ); ?>"
+      />
+      <div class="errors" aria-live="polite">
+        <p
+          id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
+          class="infotext error hidden"
+        >
+          <span class="dashicons dashicons-no"></span>
+          <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+        </p>
+      </div>
+    </div>
+    <div class="buttons">
+      <button
+        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
+        class="button button-small button-secondary"
+        title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
+        <?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+      >
+        <?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+      </button>
+      <button
+        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
+        class="button button-small button-primary"
+        title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
+        <?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+      >
+        <?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+      </button>
+      <?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
+        <button
+          id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
+          class="button button-small button-primary"
+          title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
+          <?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
+        >
+          <?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
+        </button>
+      <?php endif ?>
+      <img
+        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
+        class="loader hidden"
+        src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+        width="16"
+        height="16"
+      />
+    </div>
+    <div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
+      <p
+        id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
+        class="infotext ok hidden"
+      >
+        <span class="dashicons dashicons-yes"></span>
+        <?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
+      </p>
+      <p
+        id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
+        class="infotext error hidden"
+      >
+        <span class="dashicons dashicons-no"></span>
+        <?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
+      </p>
+      <p
+        id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
+        class="infotext ok hidden"
+      >
+        <span class="dashicons dashicons-yes"></span>
+        <?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
+      </p>
+      <p
+        id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
+        class="infotext error hidden"
+      >
+        <span class="dashicons dashicons-yes"></span>
+        <?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
+      </p>
+      <p
+        id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
+        class="infotext error hidden"
+      >
+        <span class="dashicons dashicons-no"></span>
+        <?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
+      </p>
+    </div>
+  </div>
+
+  <div class="input-set">
+    <div class="input">
+      <label
+        for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+      >
+        <?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
+      </label>
+      <input
+        id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+        class="regular-text"
+        name="1984_woo_dk_credit_invoice_number"
+        type="text"
+        autocomplete="off"
+        value="<?php echo esc_attr( $credit_invoice_number ); ?>"
+      />
+      <div class="errors" aria-live="polite">
+        <p
+          id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
+          class="infotext error hidden"
+        >
+          <span class="dashicons dashicons-no"></span>
+          <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+        </p>
+      </div>
+    </div>
+    <div class="buttons">
+      <button
+        id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
+        class="button button-small button-secondary"
+        title="Update the credit invoice number reference without generating a new credit invoice in DK"
+        <?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+      >
+        <?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+      </button>
+      <button
+        id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
+        class="button button-small button-primary"
+        title="Get the credit invoice as a PDF file"
+        <?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+      >
+        <?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+      </button>
+      <img
+        id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
+        class="loader hidden"
+        src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+        width="16"
+        height="16"
+      />
+    </div>
+  </div>
+  <?php
+}
 ?>
-
-<div
-	class="input-set"
-	aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
->
-	<div class="input">
-		<label
-			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
-			for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-		>
-			<?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
-		</label>
-		<input
-			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-			class="regular-text"
-			aria-live="polite"
-			name="1984_woo_dk_invoice_number"
-			type="text"
-			autocomplete="off"
-			value="<?php echo esc_attr( $invoice_number ); ?>"
-		/>
-		<div class="errors" aria-live="polite">
-			<p
-				id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
-				class="infotext error hidden"
-			>
-				<span class="dashicons dashicons-no"></span>
-				<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-			</p>
-		</div>
-	</div>
-	<div class="buttons">
-		<button
-			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
-			class="button button-small button-secondary"
-			title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
-			<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-		>
-			<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-		</button>
-		<button
-			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
-			class="button button-small button-primary"
-			title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
-			<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-		>
-			<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-		</button>
-		<?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
-		<button
-			id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
-			class="button button-small button-primary"
-			title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
-			<?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
-		>
-			<?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
-		</button>
-		<?php endif ?>
-		<img
-			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
-			class="loader hidden"
-			src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-			width="16"
-			height="16"
-		/>
-	</div>
-	<div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
-		<p
-			id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
-			class="infotext ok hidden"
-		>
-			<span class="dashicons dashicons-yes"></span>
-			<?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
-		</p>
-		<p
-			id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
-			class="infotext error hidden"
-		>
-			<span class="dashicons dashicons-no"></span>
-			<?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
-		</p>
-		<p
-			id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
-			class="infotext ok hidden"
-		>
-			<span class="dashicons dashicons-yes"></span>
-			<?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
-		</p>
-		<p
-			id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
-			class="infotext error hidden"
-		>
-			<span class="dashicons dashicons-yes"></span>
-			<?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
-		</p>
-		<p
-			id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
-			class="infotext error hidden"
-		>
-			<span class="dashicons dashicons-no"></span>
-			<?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
-		</p>
-	</div>
-</div>
-
-<div class="input-set">
-	<div class="input">
-		<label
-			for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-		>
-			<?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
-		</label>
-		<input
-			id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-			class="regular-text"
-			name="1984_woo_dk_credit_invoice_number"
-			type="text"
-			autocomplete="off"
-			value="<?php echo esc_attr( $credit_invoice_number ); ?>"
-		/>
-		<div class="errors" aria-live="polite">
-			<p
-				id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
-				class="infotext error hidden"
-			>
-				<span class="dashicons dashicons-no"></span>
-				<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-			</p>
-		</div>
-	</div>
-	<div class="buttons">
-		<button
-			id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
-			class="button button-small button-secondary"
-			title="Update the credit invoice number reference without generating a new credit invoice in DK"
-			<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-		>
-			<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-		</button>
-		<button
-			id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
-			class="button button-small button-primary"
-			title="Get the credit invoice as a PDF file"
-			<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-		>
-			<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-		</button>
-		<img
-			id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
-			class="loader hidden"
-			src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-			width="16"
-			height="16"
-		/>
-	</div>
-</div>

--- a/views/dk_invoice_metabox.php
+++ b/views/dk_invoice_metabox.php
@@ -5,173 +5,173 @@ declare(strict_types = 1);
 use NineteenEightyFour\NineteenEightyWoo\Helpers\Order as OrderHelper;
 
 if ( ! defined( 'ABSPATH' ) ) {
-  exit;
+	exit;
 }
 
 global $post;
-if(!empty($post)) {
-  $wc_order = wc_get_order( $post->ID );
+if ( ! empty( $post ) ) {
+	$wc_order = wc_get_order( $post->ID );
 
-  $invoice_number        = $wc_order->get_meta( '1984_woo_dk_invoice_number', true, 'edit' );
-  $credit_invoice_number = $wc_order->get_meta( '1984_woo_dk_credit_invoice_number', true, 'edit' );
+	$invoice_number        = $wc_order->get_meta( '1984_woo_dk_invoice_number', true, 'edit' );
+	$credit_invoice_number = $wc_order->get_meta( '1984_woo_dk_credit_invoice_number', true, 'edit' );
 
-  ?>
+	?>
 
   <div
-    class="input-set"
-    aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+	class="input-set"
+	aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
   >
-    <div class="input">
-      <label
-        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
-        for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-      >
-        <?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
-      </label>
-      <input
-        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-        class="regular-text"
-        aria-live="polite"
-        name="1984_woo_dk_invoice_number"
-        type="text"
-        autocomplete="off"
-        value="<?php echo esc_attr( $invoice_number ); ?>"
-      />
-      <div class="errors" aria-live="polite">
-        <p
-          id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
-          class="infotext error hidden"
-        >
-          <span class="dashicons dashicons-no"></span>
-          <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-        </p>
-      </div>
-    </div>
-    <div class="buttons">
-      <button
-        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
-        class="button button-small button-secondary"
-        title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
-        <?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-      >
-        <?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-      </button>
-      <button
-        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
-        class="button button-small button-primary"
-        title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
-        <?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-      >
-        <?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-      </button>
-      <?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
-        <button
-          id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
-          class="button button-small button-primary"
-          title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
-          <?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
-        >
-          <?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
-        </button>
-      <?php endif ?>
-      <img
-        id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
-        class="loader hidden"
-        src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-        width="16"
-        height="16"
-      />
-    </div>
-    <div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
-      <p
-        id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
-        class="infotext ok hidden"
-      >
-        <span class="dashicons dashicons-yes"></span>
-        <?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
-      </p>
-      <p
-        id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
-        class="infotext error hidden"
-      >
-        <span class="dashicons dashicons-no"></span>
-        <?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
-      </p>
-      <p
-        id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
-        class="infotext ok hidden"
-      >
-        <span class="dashicons dashicons-yes"></span>
-        <?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
-      </p>
-      <p
-        id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
-        class="infotext error hidden"
-      >
-        <span class="dashicons dashicons-yes"></span>
-        <?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
-      </p>
-      <p
-        id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
-        class="infotext error hidden"
-      >
-        <span class="dashicons dashicons-no"></span>
-        <?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
-      </p>
-    </div>
+	<div class="input">
+	  <label
+		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+		for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+	  >
+		<?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
+	  </label>
+	  <input
+		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+		class="regular-text"
+		aria-live="polite"
+		name="1984_woo_dk_invoice_number"
+		type="text"
+		autocomplete="off"
+		value="<?php echo esc_attr( $invoice_number ); ?>"
+	  />
+	  <div class="errors" aria-live="polite">
+		<p
+		  id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
+		  class="infotext error hidden"
+		>
+		  <span class="dashicons dashicons-no"></span>
+		  <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+		</p>
+	  </div>
+	</div>
+	<div class="buttons">
+	  <button
+		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
+		class="button button-small button-secondary"
+		title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
+		<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+	  >
+		<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+	  </button>
+	  <button
+		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
+		class="button button-small button-primary"
+		title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
+		<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+	  >
+		<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+	  </button>
+	  <?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
+		<button
+		  id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
+		  class="button button-small button-primary"
+		  title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
+			<?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
+		>
+			<?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
+		</button>
+	  <?php endif ?>
+	  <img
+		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
+		class="loader hidden"
+		src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+		width="16"
+		height="16"
+	  />
+	</div>
+	<div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
+	  <p
+		id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
+		class="infotext ok hidden"
+	  >
+		<span class="dashicons dashicons-yes"></span>
+		<?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
+	  </p>
+	  <p
+		id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
+		class="infotext error hidden"
+	  >
+		<span class="dashicons dashicons-no"></span>
+		<?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
+	  </p>
+	  <p
+		id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
+		class="infotext ok hidden"
+	  >
+		<span class="dashicons dashicons-yes"></span>
+		<?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
+	  </p>
+	  <p
+		id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
+		class="infotext error hidden"
+	  >
+		<span class="dashicons dashicons-yes"></span>
+		<?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
+	  </p>
+	  <p
+		id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
+		class="infotext error hidden"
+	  >
+		<span class="dashicons dashicons-no"></span>
+		<?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
+	  </p>
+	</div>
   </div>
 
   <div class="input-set">
-    <div class="input">
-      <label
-        for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-      >
-        <?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
-      </label>
-      <input
-        id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-        class="regular-text"
-        name="1984_woo_dk_credit_invoice_number"
-        type="text"
-        autocomplete="off"
-        value="<?php echo esc_attr( $credit_invoice_number ); ?>"
-      />
-      <div class="errors" aria-live="polite">
-        <p
-          id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
-          class="infotext error hidden"
-        >
-          <span class="dashicons dashicons-no"></span>
-          <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-        </p>
-      </div>
-    </div>
-    <div class="buttons">
-      <button
-        id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
-        class="button button-small button-secondary"
-        title="Update the credit invoice number reference without generating a new credit invoice in DK"
-        <?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-      >
-        <?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-      </button>
-      <button
-        id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
-        class="button button-small button-primary"
-        title="Get the credit invoice as a PDF file"
-        <?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-      >
-        <?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-      </button>
-      <img
-        id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
-        class="loader hidden"
-        src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-        width="16"
-        height="16"
-      />
-    </div>
+	<div class="input">
+	  <label
+		for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+	  >
+		<?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
+	  </label>
+	  <input
+		id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+		class="regular-text"
+		name="1984_woo_dk_credit_invoice_number"
+		type="text"
+		autocomplete="off"
+		value="<?php echo esc_attr( $credit_invoice_number ); ?>"
+	  />
+	  <div class="errors" aria-live="polite">
+		<p
+		  id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
+		  class="infotext error hidden"
+		>
+		  <span class="dashicons dashicons-no"></span>
+		  <?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+		</p>
+	  </div>
+	</div>
+	<div class="buttons">
+	  <button
+		id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
+		class="button button-small button-secondary"
+		title="Update the credit invoice number reference without generating a new credit invoice in DK"
+		<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+	  >
+		<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+	  </button>
+	  <button
+		id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
+		class="button button-small button-primary"
+		title="Get the credit invoice as a PDF file"
+		<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+	  >
+		<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+	  </button>
+	  <img
+		id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
+		class="loader hidden"
+		src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+		width="16"
+		height="16"
+	  />
+	</div>
   </div>
-  <?php
+	<?php
 }
 ?>

--- a/views/dk_invoice_metabox.php
+++ b/views/dk_invoice_metabox.php
@@ -15,157 +15,157 @@ $credit_invoice_number = $wc_order->get_meta( '1984_woo_dk_credit_invoice_number
 ?>
 
 <div
-class="input-set"
-aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+	class="input-set"
+	aria-labelledby="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
 >
-<div class="input">
-	<label
-	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
-	for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-	>
-	<?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
-	</label>
-	<input
-	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
-	class="regular-text"
-	aria-live="polite"
-	name="1984_woo_dk_invoice_number"
-	type="text"
-	autocomplete="off"
-	value="<?php echo esc_attr( $invoice_number ); ?>"
-	/>
-	<div class="errors" aria-live="polite">
-	<p
-		id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
-		class="infotext error hidden"
-	>
-		<span class="dashicons dashicons-no"></span>
-		<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-	</p>
+	<div class="input">
+		<label
+			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-label"
+			for="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+		>
+			<?php esc_html_e( 'Invoice Number', '1984-dk-woo' ); ?>
+		</label>
+		<input
+			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-input"
+			class="regular-text"
+			aria-live="polite"
+			name="1984_woo_dk_invoice_number"
+			type="text"
+			autocomplete="off"
+			value="<?php echo esc_attr( $invoice_number ); ?>"
+		/>
+		<div class="errors" aria-live="polite">
+			<p
+				id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-invalid"
+				class="infotext error hidden"
+			>
+				<span class="dashicons dashicons-no"></span>
+				<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+			</p>
+		</div>
 	</div>
-</div>
-<div class="buttons">
-	<button
-	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
-	class="button button-small button-secondary"
-	title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
-	<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-	>
-	<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-	</button>
-	<button
-	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
-	class="button button-small button-primary"
-	title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
-	<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
-	>
-	<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-	</button>
-	<?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
-	<button
-		id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
-		class="button button-small button-primary"
-		title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
-		<?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
-	>
-		<?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
-	</button>
-	<?php endif ?>
-	<img
-	id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
-	class="loader hidden"
-	src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-	width="16"
-	height="16"
-	/>
-</div>
-<div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
-	<p
-	id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
-	class="infotext ok hidden"
-	>
-	<span class="dashicons dashicons-yes"></span>
-	<?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
-	</p>
-	<p
-	id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
-	class="infotext error hidden"
-	>
-	<span class="dashicons dashicons-no"></span>
-	<?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
-	</p>
-	<p
-	id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
-	class="infotext ok hidden"
-	>
-	<span class="dashicons dashicons-yes"></span>
-	<?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
-	</p>
-	<p
-	id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
-	class="infotext error hidden"
-	>
-	<span class="dashicons dashicons-yes"></span>
-	<?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
-	</p>
-	<p
-	id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
-	class="infotext error hidden"
-	>
-	<span class="dashicons dashicons-no"></span>
-	<?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
-	</p>
-</div>
+	<div class="buttons">
+		<button
+			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-number-update-button"
+			class="button button-small button-secondary"
+			title="<?php esc_html_e( 'Update the invoice number reference without generating a new invoice in DK', '1984-dk-woo' ); ?>"
+			<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+		>
+			<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+		</button>
+		<button
+			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-get-pdf-button"
+			class="button button-small button-primary"
+			title="<?php esc_html_e( 'Get the invoice as a PDF file', '1984-dk-woo' ); ?>"
+			<?php echo empty( $invoice_number ) ? 'disabled' : ''; ?>
+		>
+			<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+		</button>
+		<?php if ( OrderHelper::can_be_invoiced( $wc_order ) ) : ?>
+		<button
+			id="nineteen-eighty-woo-dk-invoice-metabox-make-dk-invoice-button"
+			class="button button-small button-primary"
+			title="<?php esc_html_e( 'Generate a new invoice for this order in DK and assign it to this order', '1984-dk-woo' ); ?>"
+			<?php echo empty( $invoice_number ) ? '' : 'disabled'; ?>
+		>
+			<?php esc_html_e( 'Create in DK', '1984-dk-woo' ); ?>
+		</button>
+		<?php endif ?>
+		<img
+			id="nineteen-eighty-woo-dk-invoice-metabox-invoice-loader"
+			class="loader hidden"
+			src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+			width="16"
+			height="16"
+		/>
+	</div>
+	<div id="nineteen-eighty-woo-dk-invoice-messages" class="errors" aria-live="polite">
+		<p
+			id="nineteen-eighty-woo-dk-invoice-metabox-created-message"
+			class="infotext ok hidden"
+		>
+			<span class="dashicons dashicons-yes"></span>
+			<?php esc_html_e( 'Invoice has been created in DK.', '1984-dk-woo' ); ?>
+		</p>
+		<p
+			id="nineteen-eighty-woo-dk-invoice-metabox-creation-error"
+			class="infotext error hidden"
+		>
+			<span class="dashicons dashicons-no"></span>
+			<?php esc_html_e( 'Unable to create invoice in DK.', '1984-dk-woo' ); ?>
+		</p>
+		<p
+			id="nineteen-eighty-woo-dk-invoice-metabox-number-assigned-message"
+			class="infotext ok hidden"
+		>
+			<span class="dashicons dashicons-yes"></span>
+			<?php esc_html_e( 'Invoice number has been assigned.', '1984-dk-woo' ); ?>
+		</p>
+		<p
+			id="nineteen-eighty-woo-dk-invoice-metabox-number-not-assigned-error"
+			class="infotext error hidden"
+		>
+			<span class="dashicons dashicons-yes"></span>
+			<?php esc_html_e( 'Invoice number was not assigned.', '1984-dk-woo' ); ?>
+		</p>
+		<p
+			id="nineteen-eighty-woo-dk-invoice-metabox-pdf-not-found-error"
+			class="infotext error hidden"
+		>
+			<span class="dashicons dashicons-no"></span>
+			<?php esc_html_e( 'Invoice not found in DK.', '1984-dk-woo' ); ?>
+		</p>
+	</div>
 </div>
 
 <div class="input-set">
-<div class="input">
-	<label
-	for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-	>
-	<?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
-	</label>
-	<input
-	id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
-	class="regular-text"
-	name="1984_woo_dk_credit_invoice_number"
-	type="text"
-	autocomplete="off"
-	value="<?php echo esc_attr( $credit_invoice_number ); ?>"
-	/>
-	<div class="errors" aria-live="polite">
-	<p
-		id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
-		class="infotext error hidden"
-	>
-		<span class="dashicons dashicons-no"></span>
-		<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
-	</p>
+	<div class="input">
+		<label
+			for="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+		>
+			<?php esc_html_e( 'Credit Invoice Number', '1984-dk-woo' ); ?>
+		</label>
+		<input
+			id="1984-dk-woo-dk-invoice-metabox-credit-invoice-number-input"
+			class="regular-text"
+			name="1984_woo_dk_credit_invoice_number"
+			type="text"
+			autocomplete="off"
+			value="<?php echo esc_attr( $credit_invoice_number ); ?>"
+		/>
+		<div class="errors" aria-live="polite">
+			<p
+				id="nineteen-eighty-woo-dk-credit-invoice-metabox-invoice-number-invalid"
+				class="infotext error hidden"
+			>
+				<span class="dashicons dashicons-no"></span>
+				<?php esc_html_e( 'Needs to be numeric', '1984-dk-woo' ); ?>
+			</p>
+		</div>
 	</div>
-</div>
-<div class="buttons">
-	<button
-	id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
-	class="button button-small button-secondary"
-	title="Update the credit invoice number reference without generating a new credit invoice in DK"
-	<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-	>
-	<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
-	</button>
-	<button
-	id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
-	class="button button-small button-primary"
-	title="Get the credit invoice as a PDF file"
-	<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
-	>
-	<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
-	</button>
-	<img
-	id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
-	class="loader hidden"
-	src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
-	width="16"
-	height="16"
-	/>
-</div>
+	<div class="buttons">
+		<button
+			id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-number-update-button"
+			class="button button-small button-secondary"
+			title="Update the credit invoice number reference without generating a new credit invoice in DK"
+			<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+		>
+			<?php esc_html_e( 'Update', '1984-dk-woo' ); ?>
+		</button>
+		<button
+			id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-get-pdf-button"
+			class="button button-small button-primary"
+			title="Get the credit invoice as a PDF file"
+			<?php echo empty( $credit_invoice_number ) ? 'disabled' : ''; ?>
+		>
+			<?php esc_html_e( 'Get PDF', '1984-dk-woo' ); ?>
+		</button>
+		<img
+			id="nineteen-eighty-woo-dk-invoice-metabox-credit-invoice-loader"
+			class="loader hidden"
+			src="<?php echo esc_url( get_admin_url() . 'images/wpspin_light-2x.gif' ); ?>"
+			width="16"
+			height="16"
+		/>
+	</div>
 </div>

--- a/views/product_options_advanced_partial.php
+++ b/views/product_options_advanced_partial.php
@@ -9,9 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-global $post;
-
-$wc_product       = wc_get_product( $post );
+$wc_product       = wc_get_product();
 $product_currency = ProductHelper::get_currency( $wc_product );
 
 ?>

--- a/views/product_options_pricing_partial.php
+++ b/views/product_options_pricing_partial.php
@@ -9,9 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-global $post;
-
-$wc_product       = new WC_Product( $post );
+$wc_product       = wc_get_product();
 $product_currency = ProductHelper::get_currency( $wc_product );
 
 ?>

--- a/views/product_options_sku_partial.php
+++ b/views/product_options_sku_partial.php
@@ -8,9 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-global $post;
-
-$wc_product = new WC_Product( $post );
+$wc_product = wc_get_product();
 
 ?>
 


### PR DESCRIPTION
In some cases, the $post variable is not existent when this code is run, causing the whole metabox to have a fatal error and the order can not be edited at all.

This fix wraps everything that happens after `global $post;` in an (!empty()) function, so if $post is empty, nothing is run.

This is a temporary patch, we really should give a graceful error status, but I'm not 100% sure on the full functionality of the box, hence this fix.