### PR TITLE
Fixing CurrencyCode bug

### DIFF
--- a/src/Export/Product.php
+++ b/src/Export/Product.php
@@ -478,7 +478,6 @@ class Product {
 
 		if ( ProductHelper::price_sync_enabled( $wc_product ) ) {
 			$price_props = array(
-				'CurrencyCode'        => get_woocommerce_currency(),
 				'TaxPercent'          => ProductHelper::tax_rate( $wc_product ),
 				'PropositionPrice'    => ProductHelper::format_sale_price_for_dk( $wc_product ),
 				'PropositionDateFrom' => ProductHelper::format_date_on_sale_for_dk( 'from', $wc_product ),


### PR DESCRIPTION
For upstream price sync, we can't specify the CurrencyCode attribute, becaue apparantly, it stands for the procurement currency paid by the vendor, but not the currency the product is sold in.

This means that if the purchasing currency for a product is 500 EUR originally and the upstream price sync changes the code to ISK, the value changes to 500 ISK. That in turn affects margin calculations for any sale of the product substantially.

Removing this single line of code may solve the issue but this may also require some further research.