### PR TITLE
Fixing potential product sync type error

### DIFF
--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -508,7 +508,7 @@ class Products {
 			);
 
 			if ( $price_before_tax instanceof WP_Error ) {
-				return $price_before_tax;
+				return false;
 			}
 
 			$price_with_tax = self::calculate_price_after_tax(

--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -481,12 +481,12 @@ class Products {
 	 * @param stdClass $json_object A PHP object representing the JSON response
 	 *                              from the DK API.
 	 *
-	 * @return stdClass An object containing the properties
-	 *                  `price` (float or empty string),
-	 *                  `sale_price` (float or empty string),
-	 *                  `date_on_sale_from` (WC_DateTime or empty string)
-	 *                  and `date_on_sale_to` (WC_DateTime or empty string) or
-	 *                  `false` on failure.
+	 * @return stdClass|false An object containing the properties
+	 *                        `price` (float or empty string),
+	 *                        `sale_price` (float or empty string),
+	 *                        `date_on_sale_from` (WC_DateTime or empty string)
+	 *                         and `date_on_sale_to` (WC_DateTime or empty
+	 *                         string) or false` on failure.
 	 */
 	public static function get_product_price_from_json(
 		stdClass $json_object


### PR DESCRIPTION
`WP_Error` was not declared as a return type for `Products::get_product_price_from_json`. This has been fixed.