### PR TITLE
Setting menu order for new product variants on sync

### DIFF
--- a/src/Import/Products.php
+++ b/src/Import/Products.php
@@ -802,7 +802,9 @@ class Products {
 		$data_store             = WC_Data_Store::load( 'product' );
 		$affected_variation_ids = array();
 
-		foreach ( $variations_array as $v ) {
+		$variation_count = count( $wc_product->get_children() );
+
+		foreach ( $variations_array as $i => $v ) {
 			$attributes = array(
 				sanitize_title( 'attribute_' . $v->attribute_1 ) => $v->code_1,
 			);
@@ -819,6 +821,8 @@ class Products {
 
 			if ( $variation_id === 0 ) {
 				$variation = wc_get_product_object( 'variation' );
+
+				$variation->set_menu_order( intval( $i ) + $variation_count );
 
 				$variation->set_parent_id( $wc_product->get_id() );
 				$variation->set_attributes( $attributes );
@@ -843,6 +847,10 @@ class Products {
 					$variation instanceof WC_Product_Variation &&
 					$wc_product->get_id() === $variation->get_parent_id()
 				) {
+					if ( $variation->get_menu_order() < 0 ) {
+						$variation->set_menu_order( intval( $i ) + $variation_count );
+					}
+
 					$variation->set_parent_id( $wc_product->get_id() );
 					$variation->set_attributes( $attributes );
 					if ( ProductHelper::quantity_sync_enabled( $wc_product ) ) {


### PR DESCRIPTION
The product sync process now sets the menu order for product variants.